### PR TITLE
Fixes bugs with recaptcha timeout and empty file inputs

### DIFF
--- a/lib/modules/apostrophe-forms-file-field-widgets/public/js/lean.js
+++ b/lib/modules/apostrophe-forms-file-field-widgets/public/js/lean.js
@@ -12,7 +12,8 @@ apos.utils.widgetPlayers['apostrophe-forms-file-field'] = function(el, data, opt
   formsWidget.addEventListener('apos-forms-validate', function(event) {
     // We already did the hard work, this is a hidden field with the _id of the
     // attachment.
-    event.input[file.getAttribute('name')] = file.getAttribute('data-apos-forms-attachment-ids').split(',');
+    var attachmentIds = file.getAttribute('data-apos-forms-attachment-ids');
+    event.input[file.getAttribute('name')] = attachmentIds ? attachmentIds.split(',') : null;
   });
 
   var error = formsWidget.querySelector('[data-apos-forms-file-error]');

--- a/lib/modules/apostrophe-forms-widgets/public/js/lean.js
+++ b/lib/modules/apostrophe-forms-widgets/public/js/lean.js
@@ -78,7 +78,11 @@ apos.utils.widgetPlayers['apostrophe-forms'] = function (el, data, options) {
       apos.utils.removeClass(spinner, 'apos-forms-visible');
       if (err || (res && (res.status !== 'ok'))) {
         apos.utils.addClass(errorMsg, 'apos-forms-visible');
-        highlightErrors(res, recaptchaId);
+        highlightErrors(res);
+
+        if (recaptchaId) {
+          grecaptcha.reset(recaptchaId);
+        }
       } else {
         apos.utils.addClass(thankYou, 'apos-forms-visible');
         apos.utils.addClass(form, 'apos-forms-hidden');
@@ -86,7 +90,7 @@ apos.utils.widgetPlayers['apostrophe-forms'] = function (el, data, options) {
     });
   }
 
-  function highlightErrors(res, recaptchaId) {
+  function highlightErrors(res) {
     if (!res || !res.formErrors) { return; }
 
     var globalError = el.querySelector('[data-apos-forms-global-error]');
@@ -113,8 +117,6 @@ apos.utils.widgetPlayers['apostrophe-forms'] = function (el, data, options) {
       labelMessage.innerText = error.errorMessage;
       labelMessage.hidden = false;
     });
-
-    grecaptcha.reset(recaptchaId);
   }
 
   function addRecaptchaScript () {

--- a/lib/modules/apostrophe-forms-widgets/public/js/lean.js
+++ b/lib/modules/apostrophe-forms-widgets/public/js/lean.js
@@ -35,8 +35,11 @@ apos.utils.widgetPlayers['apostrophe-forms'] = function (el, data, options) {
 
     var recaptchaError = el.querySelector('[data-apos-forms-recaptcha-error]');
 
+    var recaptchaId;
     if (recaptchaSlot) {
-      const token = grecaptcha.getResponse(recaptchaSlot.getAttribute('data-apos-recaptcha-id'));
+      recaptchaId = recaptchaSlot.getAttribute('data-apos-recaptcha-id');
+      var token = grecaptcha.getResponse(recaptchaId);
+
       if (!token) {
         apos.utils.addClass(recaptchaError, 'apos-forms-visible');
         return;
@@ -75,7 +78,7 @@ apos.utils.widgetPlayers['apostrophe-forms'] = function (el, data, options) {
       apos.utils.removeClass(spinner, 'apos-forms-visible');
       if (err || (res && (res.status !== 'ok'))) {
         apos.utils.addClass(errorMsg, 'apos-forms-visible');
-        highlightErrors(res);
+        highlightErrors(res, recaptchaId);
       } else {
         apos.utils.addClass(thankYou, 'apos-forms-visible');
         apos.utils.addClass(form, 'apos-forms-hidden');
@@ -83,7 +86,7 @@ apos.utils.widgetPlayers['apostrophe-forms'] = function (el, data, options) {
     });
   }
 
-  function highlightErrors(res) {
+  function highlightErrors(res, recaptchaId) {
     if (!res || !res.formErrors) { return; }
 
     var globalError = el.querySelector('[data-apos-forms-global-error]');
@@ -110,6 +113,8 @@ apos.utils.widgetPlayers['apostrophe-forms'] = function (el, data, options) {
       labelMessage.innerText = error.errorMessage;
       labelMessage.hidden = false;
     });
+
+    grecaptcha.reset(recaptchaId);
   }
 
   function addRecaptchaScript () {
@@ -127,7 +132,7 @@ apos.utils.widgetPlayers['apostrophe-forms'] = function (el, data, options) {
   }
 
   function renderCaptchas () {
-    const recaptchaSlots = document.querySelectorAll('[data-apos-recaptcha-slot]');
+    var recaptchaSlots = document.querySelectorAll('[data-apos-recaptcha-slot]');
 
     recaptchaSlots.forEach(function(slot) {
       var slotId = grecaptcha.render(


### PR DESCRIPTION
1. If no file was added, a console error was thrown.
2. If there was a server validated form error, the recaptcha token would remain, but it would be seen as a duplicate and thus rejected on the server end. I needed to reset it when there was a server error.