### PR TITLE
Removes requirement for query parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,6 @@ module.exports = {
         label: 'Query Parameter Keys',
         type: 'array',
         titleField: 'key',
-        required: true,
         help: 'Create an array item for each query parameter value you wish to capture.',
         schema: [
           {
@@ -248,7 +247,7 @@ module.exports = {
           });
         }
 
-        if (form.enableQueryParams) {
+        if (form.enableQueryParams && form.queryParamList.length > 0) {
           self.processQueryParams(req, form, input, output, fieldNames);
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-forms",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Build forms for ApostropheCMS in a simple user interface.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This is to deal with a bug in Apostrophe where the required field rejected saving even when hidden by `showFields`.