### PR TITLE
Set apostrophe minimal version needed in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "request-promise": "^4.2.4"
   },
   "peerDependencies": {
-    "apostrophe": "2.x"
+    "apostrophe": "^2.89.0"
   }
 }


### PR DESCRIPTION
The method `self.apiRoute` used in the main `index.js` file has been introduced in version 2.89.0 of apostrophe. This involves informing users that they must have a version of apostrophe equal to or greater than this one in their project.

This pull request simply modifies the `package.json` in this way :)