### PR TITLE
Adds back an email field to be used as the sender address

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ module.exports = {
   name: 'apostrophe-forms',
   label: 'Form',
   extend: 'apostrophe-pieces',
+  seo: false,
+  openGraph: false,
   moogBundle: {
     directory: 'lib/modules',
     modules: [
@@ -155,7 +157,7 @@ module.exports = {
           {
             name: 'conditions',
             label: 'Set Conditions for this Notification',
-            help: 'e.g., only notify this email address if the "country" field is set to "Austria. All conditions must be met. Add the email again with another conditional set if needed."',
+            help: 'For example, if you only notify this email address if the "country" field is set to "Austria". All conditions must be met. Add the email again with another conditional set if needed."',
             type: 'array',
             titleField: 'value',
             schema: [
@@ -175,6 +177,13 @@ module.exports = {
             ]
           }
         ]
+      },
+      {
+        name: 'email',
+        label: 'Primary internal email address',
+        type: 'string',
+        required: true,
+        help: 'You may enter one from the previous list. This is the address that will be used as the "from" address on any generated email messages.'
       }
     ] : []).concat(options.addFields || []);
 
@@ -183,7 +192,10 @@ module.exports = {
       'thankYouBody',
       'sendConfirmationEmail',
       'emailConfirmationField'
-    ].concat(options.emailSubmissions !== false ? ['emails'] : []);
+    ].concat(options.emailSubmissions !== false ? [
+      'emails',
+      'email'
+    ] : []);
 
     options.arrangeFields = (options.arrangeFields || []).concat([
       {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/apostrophecms/apostrophe-forms#readme",
   "devDependencies": {
-    "apostrophe": "^2.101.0",
+    "apostrophe": "^2.98.1",
     "axios": "^0.19.0",
     "eslint": "^4.15.0",
     "eslint-config-apostrophe": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-forms",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Build forms for ApostropheCMS in a simple user interface.",
   "main": "index.js",
   "scripts": {
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/apostrophecms/apostrophe-forms#readme",
   "devDependencies": {
-    "apostrophe": "^2.98.1",
+    "apostrophe": "^2.101.0",
     "axios": "^0.19.0",
     "eslint": "^4.15.0",
     "eslint-config-apostrophe": "^2.0.2",

--- a/test/test.js
+++ b/test/test.js
@@ -87,7 +87,7 @@ describe('Forms module', function () {
   it('should have a default collection for submissions', function (done) {
     apos.db.collection('aposFormSubmissions', function (err, collection) {
       assert(!err);
-      assert(collection.namespace === 'test.aposFormSubmissions');
+      assert(collection);
       done();
     });
   });


### PR DESCRIPTION
The `email` field was removed to allow sending results to multiple email addresses, but it's still needed to send messages from the app in some transports.

The test change was because there was no longer a `namespace` property on the collection, though a collection did come back. I used the core Apostrophe `attachments.js` test as a guide for that change.