### PR TITLE
Hotfix/notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 1.5.1 2020-01-22
+
+- Fixes a bug where the submission notification process did not test comma-separated values property for values stored as strings.
+
 ## 1.5.0 2020-01-08
 
 - Adds checkbox fields as an option for a conditional fieldset control.

--- a/index.js
+++ b/index.js
@@ -395,12 +395,11 @@ module.exports = {
             return;
           }
 
-          if (!data[condition.field]) {
+          let answer = data[condition.field];
+
+          if (!answer) {
             passed = false;
-          } else if (typeof data[condition.field] === 'string' &&
-            data[condition.field] !== condition.value) {
-            passed = false;
-          } else if (Array.isArray(data[condition.field])) {
+          } else {
             // Regex for comma-separation from https://stackoverflow.com/questions/11456850/split-a-string-by-commas-but-ignore-commas-within-double-quotes-using-javascript/11457952#comment56094979_11457952
             const regex = /(".*?"|[^",]+)(?=\s*,|\s*$)/g;
             let acceptable = condition.value.match(regex);
@@ -416,7 +415,12 @@ module.exports = {
               return value.trim();
             });
 
-            if (!(data[condition.field].some(val => acceptable.includes(val)))) {
+            // If the value is stored as a string, convert to an array for checking.
+            if (!Array.isArray(answer)) {
+              answer = [answer];
+            }
+
+            if (!(answer.some(val => acceptable.includes(val)))) {
               passed = false;
             }
           }
@@ -431,6 +435,10 @@ module.exports = {
 
       if (self.options.testing) {
         return emails;
+      }
+
+      if (emails.length === 0) {
+        return null;
       }
 
       for (const key in data) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-forms",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Build forms for ApostropheCMS in a simple user interface.",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -402,7 +402,7 @@ describe('Forms module', function () {
           },
           {
             "field": "DogBreed",
-            "value": "Cesky Terrier"
+            "value": "Cesky Terrier, Pumi"
           }
         ]
       },


### PR DESCRIPTION
We previously only split comma-separated conditions if the value was stored as an array (only checkboxes). This does that for all fields.