### PR TITLE
Hotfix/text input types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 1.6.0 2020-02-26
+
+- Adds the option to select a more specific input type for text fields (e.g., email, password, telephone). Thanks to Jose96GIT for the contribution.
+
 ## 1.5.1 2020-01-22
 
 - Fixes a bug where the submission notification process did not test comma-separated values property for values stored as strings.

--- a/lib/modules/apostrophe-forms-text-field-widgets/index.js
+++ b/lib/modules/apostrophe-forms-text-field-widgets/index.js
@@ -12,15 +12,11 @@ module.exports = {
       name: 'inputType',
       label: 'Input Type',
       type: 'select',
-      help: 'You should choose the type of field that is going to be, like an email, a simple text...',
+      help: 'If you are requesting certain formatted information (e.g., email, url, phone number), select the relevant input type here. If not, use "Text".',
       choices: [
         {
           label: 'Text',
           value: 'text'
-        },
-        {
-          label: 'Password',
-          value: 'password'
         },
         {
           label: 'Email',
@@ -31,8 +27,12 @@ module.exports = {
           value: 'tel'
         },
         {
-          label: 'Url',
+          label: 'URL',
           value: 'url'
+        },
+        {
+          label: 'Password',
+          value: 'password'
         }
       ],
       def: 'text'
@@ -41,8 +41,8 @@ module.exports = {
   construct: function(self, options) {
     options.arrangeFields = options.arrangeFields.map(group => {
       if (group.name === 'settings') {
-        group.fields.push('inputType');
         group.fields.push('placeholder');
+        group.fields.push('inputType');
       }
 
       return group;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-forms",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Build forms for ApostropheCMS in a simple user interface.",
   "main": "index.js",
   "scripts": {
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/apostrophecms/apostrophe-forms#readme",
   "devDependencies": {
-    "apostrophe": "^2.98.1",
+    "apostrophe": "^2.102.5",
     "axios": "^0.19.0",
     "eslint": "^4.15.0",
     "eslint-config-apostrophe": "^2.0.2",


### PR DESCRIPTION
Little adjustment to field order and help text. Then updated apos for the `qs` audit warning.