### PR TITLE
Adds a date input type with pattern fallback

### DIFF
--- a/lib/modules/apostrophe-forms-text-field-widgets/index.js
+++ b/lib/modules/apostrophe-forms-text-field-widgets/index.js
@@ -31,6 +31,10 @@ module.exports = {
           value: 'url'
         },
         {
+          label: 'Date',
+          value: 'date'
+        },
+        {
           label: 'Password',
           value: 'password'
         }
@@ -38,7 +42,7 @@ module.exports = {
       def: 'text'
     }
   ],
-  construct: function(self, options) {
+  construct: function (self, options) {
     options.arrangeFields = options.arrangeFields.map(group => {
       if (group.name === 'settings') {
         group.fields.push('placeholder');
@@ -48,7 +52,7 @@ module.exports = {
       return group;
     });
 
-    self.sanitizeFormField = function(req, form, widget, input, output) {
+    self.sanitizeFormField = function (req, form, widget, input, output) {
       output[widget.fieldName] = self.apos.launder.string(input[widget.fieldName]);
     };
   }

--- a/lib/modules/apostrophe-forms-text-field-widgets/views/widget.html
+++ b/lib/modules/apostrophe-forms-text-field-widgets/views/widget.html
@@ -6,4 +6,16 @@
   {% if not widget.required %} {{ __("(Optional)") }}{% endif %}
   <span class="apos-forms-label-message" data-apos-input-message="{{ widget.fieldName}}" hidden></span>
 </label>
-<input class="apos-forms-input" type="{{ widget.inputType or "text" }}" id="{{ id }}" name="{{ widget.fieldName}}" placeholder="{{widget.placeholder}}" {% if widget.required %}required{% endif %} />
+{% if widget.inputType == 'date' %}
+  <p>
+    <small class="apos-forms-help">{{ __("(YYYY-MM-DD)") }}</small>
+  </p>
+{% endif %}
+<input class="apos-forms-input" type="{{ widget.inputType or "text" }}"
+  id="{{ id }}" name="{{ widget.fieldName}}"
+  placeholder="{{widget.placeholder}}"
+  {% if widget.inputType == 'date' %}
+    pattern="[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])"
+  {% endif %}
+  {% if widget.required %}required{% endif %}
+/>


### PR DESCRIPTION
The pattern fallback is mainly for Safari, which doesn't support the date type. I kept the help text light because I didn't want to confuse people _too much_ who are using other browsers where the date field might not format the date exactly the same way (the input field value will be formatted like that).

And the help text is English-based, but in a translatable block.