### PR TITLE
implemented dropdown as an alternate style for checkboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## 1.9.0 2020-06-17
+
+- Introduced multiselect dropdowns as an alternate style choice available to form creators when they select the "checkboxes" widget. The provided CSS is basic but the DOM structure is intended to be suitable for styling as you see fit.
+- Added the `checkboxLabel` option to the `apostrophe-forms-checkboxes-field-widgets` module. This is a module-level option; it should be set when configuring the module, not every time it is used. If set to `first`, the label text appears before the checkbox or dropdown element. If set to `last`, it appears after. In both cases, the `input` checkbox is nested inside the `label` DOM element, for easier styling of the choice as a whole. For backwards compatibility, the default setting is `legacy`, in which the `input` element is not nested in `label`.
+
 ## 1.8.2 2020-05-14
 
 - Bump peer dependency on the apostrophe module to a minimum of 2.105.2 because of the need for a working version of `apos.utils.emit`. However we do recommend updating to the latest in the apostrophe module 2.x series when updating this module. Specifically we recommend setting your dependencies on all Apostrophe modules using the `^`, i.e. `^2.0.0`. When you are ready to test an update of your dependencies use `npm update`, then review your project's functionality before deploying.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.9.0 2020-06-17
 
 - Introduced multiselect dropdowns as an alternate style choice available to form creators when they select the "checkboxes" widget. The provided CSS is basic but the DOM structure is intended to be suitable for styling as you see fit.
-- Added the `checkboxLabel` option to the `apostrophe-forms-checkboxes-field-widgets` module. This is a module-level option; it should be set when configuring the module, not every time it is used. If set to `first`, the label text appears before the checkbox or dropdown element. If set to `last`, it appears after. In both cases, the `input` checkbox is nested inside the `label` DOM element, for easier styling of the choice as a whole. For backwards compatibility, the default setting is `legacy`, in which the `input` element is not nested in `label`.
+- Added the `optionLabelPosition` option to the `apostrophe-forms-checkboxes-field-widgets` and `apostrophe-forms-radio-field-widgets` modules. If `optionLabelPosition` is set to `'first'` or `'last'`, the input elements for both radio and checkbox inputs are nested inside the label, with the label's text appearing first or last as appropriate. If no relevant option is set, for backwards compatibility the input is not nested in the label checkboxLabel. This can be explicitly chosen by setting the appropriate option to `'legacy'`. This is more difficult to style, so we recommend setting `optionLabelPosition` to `first` or `last`. You may set the option for both modules by setting it for `apostrophe-forms-base-field-widgets`, which they both inherit from.
 
 ## 1.8.2 2020-05-14
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ Enable the modules in your `app.js` file as with other modules:
 // in app.js
 modules: {
   // ...,
-  'apostrophe-forms': {},
+  'apostrophe-forms': {
+    // Best practice: set to first or last so that inputs are nested in labels
+    // and easier to style
+    optionLabelPosition: 'last'
+  },
   'apostrophe-forms-widgets': {},
   // Enable only the field widgets that your application needs to make it
   // easier for application/website managers.
@@ -62,6 +66,8 @@ If `apostrophe-email` is configured, submissions can be sent to multiple email a
 
 ## Styling
 
+### Disabling the starter styles
+
 Starter styles for user-facing forms are included in a forms.less file. These offer some spacing as well as styling for error states. If you do not want to use these, pass the `disableBaseStyles: true` option to `apostrophe-forms-widgets`. This file can also be used to identify the error state classes that you should style in your project.
 
 ```javascript
@@ -69,6 +75,8 @@ Starter styles for user-facing forms are included in a forms.less file. These of
   disableBaseStyles: true
 },
 ```
+
+### Custom class prefix
 
 Need more control over your styling? You can include your own class prefix that will be in included on most of the labels, inputs, and message/error elements within the forms. The class that is created uses the [BEM](http://getbem.com/naming/) convention. You add the prefix you want in the `apostrophe-forms` configuration.
 
@@ -78,6 +86,23 @@ Need more control over your styling? You can include your own class prefix that 
 }
 ```
 This results in a class like `my-form__input` being added to input elements in the form, for example.
+
+### Controlling the option label position
+
+The `apostrophe-forms-checkboxes-field-widgets` and `apostrophe-forms-radio-field-widgets` modules both support `optionLabelPosition`. If `optionLabelPosition` is set to `'first'` or `'last'`, the input elements for both radio and checkbox inputs are nested inside the label, with the label's text appearing first or last as appropriate. If no relevant option is set, for backwards compatibility the input is not nested in the label checkboxLabel. This can be explicitly chosen by setting the appropriate option to `'legacy'`. This is more difficult to style, so we recommend setting `optionLabelPosition` to `first` or `last`. You may set the option for both modules by setting it for `apostrophe-forms-base-field-widgets`, which they both inherit from.
+
+```javascript
+'apostrophe-forms-checkboxes-field-widgets': {
+  optionLabelPosition: 'first',
+},
+'apostrophe-forms-radio-field-widgets': {
+  optionLabelPosition: 'last',
+},
+// OR, we can set it for both in one place
+'apostrophe-forms-base-field-widgets': {
+  optionLabelPosition: 'first',
+},
+```
 
 ## Using reCAPTCHA for user validation
 

--- a/lib/modules/apostrophe-forms-checkboxes-field-widgets/index.js
+++ b/lib/modules/apostrophe-forms-checkboxes-field-widgets/index.js
@@ -23,14 +23,29 @@ module.exports = {
           help: 'The value saved (as text) in the database. If not entered, the label will be used.'
         }
       ]
+    },
+    {
+      name: 'style',
+      label: 'Display Style',
+      type: 'select',
+      def: 'checkboxes',
+      choices: [
+        {
+          label: 'Inline List of Checkboxes',
+          value: 'checkboxes'
+        },
+        {
+          label: 'Dropdown Menu of Checkboxes',
+          value: 'dropdown'
+        }
+      ]
     }
   ],
   construct: function (self, options) {
     options.arrangeFields = options.arrangeFields.map(group => {
       if (group.name === 'settings') {
-        group.fields.push('choices');
+        group.fields.push('choices', 'style');
       }
-
       return group;
     });
 

--- a/lib/modules/apostrophe-forms-checkboxes-field-widgets/index.js
+++ b/lib/modules/apostrophe-forms-checkboxes-field-widgets/index.js
@@ -42,12 +42,16 @@ module.exports = {
     }
   ],
   construct: function (self, options) {
-    options.arrangeFields = options.arrangeFields.map(group => {
-      if (group.name === 'settings') {
-        group.fields.push('choices', 'style');
-      }
-      return group;
-    });
+    var advanced = options.arrangeFields.find(group => group.name === 'advanced');
+    if (!advanced) {
+      options.arrangeFields.push({
+        name: 'advanced',
+        label: 'Advanced',
+        fields: [ 'style' ]
+      });
+    } else {
+      advanced.fields.push('style');
+    }
 
     self.sanitizeFormField = async function (req, form, widget, input, output) {
       // Get the options from that form for the widget

--- a/lib/modules/apostrophe-forms-checkboxes-field-widgets/index.js
+++ b/lib/modules/apostrophe-forms-checkboxes-field-widgets/index.js
@@ -42,7 +42,7 @@ module.exports = {
     }
   ],
   construct: function (self, options) {
-    var advanced = options.arrangeFields.find(group => group.name === 'advanced');
+    const advanced = options.arrangeFields.find(group => group.name === 'advanced');
     if (!advanced) {
       options.arrangeFields.push({
         name: 'advanced',

--- a/lib/modules/apostrophe-forms-checkboxes-field-widgets/public/js/lean.js
+++ b/lib/modules/apostrophe-forms-checkboxes-field-widgets/public/js/lean.js
@@ -40,11 +40,11 @@ apos.utils.widgetPlayers['apostrophe-forms-checkboxes-field'] = function(el, dat
     toggle.onclick = function(e) {
       e.stopPropagation();
       e.preventDefault();
-      var dropdown = el.querySelector('.apos-forms-checkboxes-dropdown');
+      var dropdown = el.querySelector('.apos-forms-checkboxes--dropdown');
       if (!dropdown) {
         return;
       }
-      var active = 'apos-forms-checkboxes-dropdown--active';
+      var active = 'apos-forms-checkboxes--dropdown-active';
       if (dropdown.classList.contains(active)) {
         dropdown.classList.remove(active);
       } else {

--- a/lib/modules/apostrophe-forms-checkboxes-field-widgets/public/js/lean.js
+++ b/lib/modules/apostrophe-forms-checkboxes-field-widgets/public/js/lean.js
@@ -34,4 +34,22 @@ apos.utils.widgetPlayers['apostrophe-forms-checkboxes-field'] = function(el, dat
       });
     });
   }
+
+  var toggle = el.querySelector('[data-apos-toggle]');
+  if (toggle) {
+    toggle.onclick = function(e) {
+      e.stopPropagation();
+      e.preventDefault();
+      var dropdown = el.querySelector('.apos-forms-checkboxes-dropdown');
+      if (!dropdown) {
+        return;
+      }
+      var active = 'apos-forms-checkboxes-dropdown--active';
+      if (dropdown.classList.contains(active)) {
+        dropdown.classList.remove(active);
+      } else {
+        dropdown.classList.add(active);
+      }
+    };
+  }
 };

--- a/lib/modules/apostrophe-forms-checkboxes-field-widgets/public/js/lean.js
+++ b/lib/modules/apostrophe-forms-checkboxes-field-widgets/public/js/lean.js
@@ -35,12 +35,12 @@ apos.utils.widgetPlayers['apostrophe-forms-checkboxes-field'] = function(el, dat
     });
   }
 
-  var toggle = el.querySelector('[data-apos-toggle]');
+  var toggle = el.querySelector('[data-apos-form-toggle]');
   if (toggle) {
     toggle.onclick = function(e) {
       e.stopPropagation();
       e.preventDefault();
-      var dropdown = el.querySelector('.apos-forms-checkboxes--dropdown');
+      var dropdown = el.querySelector('[data-apos-form-dropdown]');
       if (!dropdown) {
         return;
       }

--- a/lib/modules/apostrophe-forms-checkboxes-field-widgets/views/widget.html
+++ b/lib/modules/apostrophe-forms-checkboxes-field-widgets/views/widget.html
@@ -9,7 +9,7 @@
   {% set checkboxLabel = 'last' %}
 {% endif %}
 
-<fieldset class="apos-forms-fieldset apos-forms-checkboxes-{{ style }} {{ classPrefix + '__fieldset' if classPrefix }}">
+<fieldset class="apos-forms-fieldset apos-forms-checkboxes--{{ style }} {{ classPrefix + '__fieldset' if classPrefix }}">
   {% if style == 'checkboxes' %}
     <legend {% if classPrefix %}class="{{ classPrefix + '__legend' }}"{% endif %}>{{ widget.fieldLabel}}
     {% if not widget.required %} {{ __("(Optional)") }}{% endif %}</legend>

--- a/lib/modules/apostrophe-forms-checkboxes-field-widgets/views/widget.html
+++ b/lib/modules/apostrophe-forms-checkboxes-field-widgets/views/widget.html
@@ -9,7 +9,7 @@
   {% set checkboxLabel = 'last' %}
 {% endif %}
 
-<fieldset class="apos-forms-fieldset apos-forms-checkboxes--{{ style }} {{ classPrefix + '__fieldset' if classPrefix }}">
+<fieldset {% if style == 'dropdown' %}data-apos-form-dropdown{% endif %} class="apos-forms-fieldset apos-forms-checkboxes--{{ style }} {{ classPrefix + '__fieldset' if classPrefix }}">
   {% if style == 'checkboxes' %}
     <legend {% if classPrefix %}class="{{ classPrefix + '__legend' }}"{% endif %}>{{ widget.fieldLabel}}
     {% if not widget.required %} {{ __("(Optional)") }}{% endif %}</legend>
@@ -32,7 +32,7 @@
       {% endif %}
     {% endfor %}
   {% else %}
-    <button data-apos-toggle class="apos-forms-checkboxes-toggle {% if classPrefix %}{{ classPrefix + '__toggle' }}{% endif %}">{{ widget.fieldLabel}}
+    <button data-apos-form-toggle class="apos-forms-checkboxes-toggle {% if classPrefix %}{{ classPrefix + '__toggle' }}{% endif %}">{{ widget.fieldLabel}}
     {% if not widget.required %} {{ __("(Optional)") }}{% endif %}</button>
     <div class="apos-forms-checkboxes-dropdown-choices">
       {% for choice in widget.choices %}

--- a/lib/modules/apostrophe-forms-checkboxes-field-widgets/views/widget.html
+++ b/lib/modules/apostrophe-forms-checkboxes-field-widgets/views/widget.html
@@ -2,13 +2,47 @@
 {% set id = apos.utils.generateId() %}
 {% set widget = data.widget %}
 {% set classPrefix = data.widget.classPrefix %}
-<fieldset class="apos-forms-fieldset {{ classPrefix + '__fieldset' if classPrefix }}">
-  <legend {% if classPrefix %}class="{{ classPrefix + '__legend' }}"{% endif %}>{{ widget.fieldLabel}}</legend>
-  {% if not widget.required %} {{ __("(Optional)") }}{% endif %}
-  {% for choice in widget.choices %}
-    {% set choiceId = id + apos.utils.slugify(choice.value) %}
-    <input {% if classPrefix %}class="{{ classPrefix + '__input' }}"{% endif %} type="checkbox" id="{{ choiceId }}" name="{{ widget.fieldName}}" value="{{ choice.value }}">
-    <label {% if classPrefix %}class="{{ classPrefix + '__label' }}"{% endif %} for="{{ choiceId }}">{{ choice.label }}</label>
-  {% endfor %}
+{% set style = data.widget.style or "checkboxes" %}
+
+{% set checkboxLabel = module.getOption('checkboxLabel', 'legacy') %}
+{% if style == 'dropdown' and checkboxLabel == 'legacy' %}
+  {% set checkboxLabel = 'last' %}
+{% endif %}
+
+<fieldset class="apos-forms-fieldset apos-forms-checkboxes-{{ style }} {{ classPrefix + '__fieldset' if classPrefix }}">
+  {% if style == 'checkboxes' %}
+    <legend {% if classPrefix %}class="{{ classPrefix + '__legend' }}"{% endif %}>{{ widget.fieldLabel}}
+    {% if not widget.required %} {{ __("(Optional)") }}{% endif %}</legend>
+    {% for choice in widget.choices %}
+      {% set choiceId = id + apos.utils.slugify(choice.value) %}
+      {% if checkboxLabel == 'first' %}
+        <label {% if classPrefix %}class="{{ classPrefix + '__label' }}"{% endif %} for="{{ choiceId }}">
+          {{ choice.label }}
+          <input {% if classPrefix %}class="{{ classPrefix + '__input' }}"{% endif %} type="checkbox" id="{{ choiceId }}" name="{{ widget.fieldName}}" value="{{ choice.value }}">
+        </label>
+      {% elseif checkboxLabel == 'last' %}
+        <label {% if classPrefix %}class="{{ classPrefix + '__label' }}"{% endif %} for="{{ choiceId }}">
+          <input {% if classPrefix %}class="{{ classPrefix + '__input' }}"{% endif %} type="checkbox" id="{{ choiceId }}" name="{{ widget.fieldName}}" value="{{ choice.value }}">
+          {{ choice.label }}
+        </label>
+      {% else %}
+        {# for bc this is the default. Harder to style because there is no row container #}
+        <input {% if classPrefix %}class="{{ classPrefix + '__input' }}"{% endif %} type="checkbox" id="{{ choiceId }}" name="{{ widget.fieldName}}" value="{{ choice.value }}">
+        <label {% if classPrefix %}class="{{ classPrefix + '__label' }}"{% endif %} for="{{ choiceId }}">{{ choice.label }}</label>
+      {% endif %}
+    {% endfor %}
+  {% else %}
+    <button data-apos-toggle {% if classPrefix %}class="{{ classPrefix + '__toggle' }}"{% endif %}>{{ widget.fieldLabel}}
+    {% if not widget.required %} {{ __("(Optional)") }}{% endif %}</button>
+    <div class="apos-forms-checkboxes-dropdown-choices">
+      {% for choice in widget.choices %}
+        {% set choiceId = id + apos.utils.slugify(choice.value) %}
+        <label {% if classPrefix %}class="{{ classPrefix + '__label' }}"{% endif %} for="{{ choiceId }}">
+          <input {% if classPrefix %}class="{{ classPrefix + '__input' }}"{% endif %} type="checkbox" id="{{ choiceId }}" name="{{ widget.fieldName}}" value="{{ choice.value }}">
+          {{ choice.label }}
+        </label>
+      {% endfor %}
+    </div>
+  {% endif %}
   <p data-apos-input-message="{{ widget.fieldName}}" hidden></p>
 </fieldset>

--- a/lib/modules/apostrophe-forms-checkboxes-field-widgets/views/widget.html
+++ b/lib/modules/apostrophe-forms-checkboxes-field-widgets/views/widget.html
@@ -11,8 +11,8 @@
 
 <fieldset {% if style == 'dropdown' %}data-apos-form-dropdown{% endif %} class="apos-forms-fieldset apos-forms-checkboxes--{{ style }} {{ classPrefix + '__fieldset' if classPrefix }}">
   {% if style == 'checkboxes' %}
-    <legend {% if classPrefix %}class="{{ classPrefix + '__legend' }}"{% endif %}>{{ widget.fieldLabel}}
-    {% if not widget.required %} {{ __("(Optional)") }}{% endif %}</legend>
+    <legend {% if classPrefix %}class="{{ classPrefix + '__legend' }}"{% endif %}>{{ widget.fieldLabel}}</legend>
+    {% if not widget.required %}<span class="apos-form-field-optional"> {{ __("(Optional)") }}</span>{% endif %}
     {% for choice in widget.choices %}
       {% set choiceId = id + apos.utils.slugify(choice.value) %}
       {% if checkboxLabel == 'first' %}
@@ -33,7 +33,7 @@
     {% endfor %}
   {% else %}
     <button data-apos-form-toggle class="apos-forms-checkboxes-toggle {% if classPrefix %}{{ classPrefix + '__toggle' }}{% endif %}">{{ widget.fieldLabel}}
-    {% if not widget.required %} {{ __("(Optional)") }}{% endif %}</button>
+    {% if not widget.required %}<span class="apos-form-field-optional"> {{ __("(Optional)") }}</span>{% endif %}</button>
     <div class="apos-forms-checkboxes-dropdown-choices">
       {% for choice in widget.choices %}
         {% set choiceId = id + apos.utils.slugify(choice.value) %}

--- a/lib/modules/apostrophe-forms-checkboxes-field-widgets/views/widget.html
+++ b/lib/modules/apostrophe-forms-checkboxes-field-widgets/views/widget.html
@@ -4,7 +4,7 @@
 {% set classPrefix = data.widget.classPrefix %}
 {% set style = data.widget.style or "checkboxes" %}
 
-{% set checkboxLabel = module.getOption('checkboxLabel', 'legacy') %}
+{% set checkboxLabel = module.getOption('optionLabelPosition', 'legacy') %}
 {% if style == 'dropdown' and checkboxLabel == 'legacy' %}
   {% set checkboxLabel = 'last' %}
 {% endif %}

--- a/lib/modules/apostrophe-forms-checkboxes-field-widgets/views/widget.html
+++ b/lib/modules/apostrophe-forms-checkboxes-field-widgets/views/widget.html
@@ -32,7 +32,7 @@
       {% endif %}
     {% endfor %}
   {% else %}
-    <button data-apos-toggle {% if classPrefix %}class="{{ classPrefix + '__toggle' }}"{% endif %}>{{ widget.fieldLabel}}
+    <button data-apos-toggle class="apos-forms-checkboxes-toggle {% if classPrefix %}{{ classPrefix + '__toggle' }}{% endif %}">{{ widget.fieldLabel}}
     {% if not widget.required %} {{ __("(Optional)") }}{% endif %}</button>
     <div class="apos-forms-checkboxes-dropdown-choices">
       {% for choice in widget.choices %}

--- a/lib/modules/apostrophe-forms-checkboxes-field-widgets/views/widget.html
+++ b/lib/modules/apostrophe-forms-checkboxes-field-widgets/views/widget.html
@@ -37,10 +37,17 @@
     <div class="apos-forms-checkboxes-dropdown-choices">
       {% for choice in widget.choices %}
         {% set choiceId = id + apos.utils.slugify(choice.value) %}
-        <label {% if classPrefix %}class="{{ classPrefix + '__label' }}"{% endif %} for="{{ choiceId }}">
-          <input {% if classPrefix %}class="{{ classPrefix + '__input' }}"{% endif %} type="checkbox" id="{{ choiceId }}" name="{{ widget.fieldName}}" value="{{ choice.value }}">
-          {{ choice.label }}
-        </label>
+        {% if checkboxLabel == 'first' %}
+          <label {% if classPrefix %}class="{{ classPrefix + '__label' }}"{% endif %} for="{{ choiceId }}">
+            {{ choice.label }}
+            <input {% if classPrefix %}class="{{ classPrefix + '__input' }}"{% endif %} type="checkbox" id="{{ choiceId }}" name="{{ widget.fieldName}}" value="{{ choice.value }}">
+          </label>
+        {% else %}
+          <label {% if classPrefix %}class="{{ classPrefix + '__label' }}"{% endif %} for="{{ choiceId }}">
+            <input {% if classPrefix %}class="{{ classPrefix + '__input' }}"{% endif %} type="checkbox" id="{{ choiceId }}" name="{{ widget.fieldName}}" value="{{ choice.value }}">
+            {{ choice.label }}
+          </label>
+        {% endif %}
       {% endfor %}
     </div>
   {% endif %}

--- a/lib/modules/apostrophe-forms-file-field-widgets/views/widget.html
+++ b/lib/modules/apostrophe-forms-file-field-widgets/views/widget.html
@@ -4,7 +4,7 @@
 {% set classPrefix = data.widget.classPrefix %}
 <label for="{{ id }}" class="apos-forms-label {{classPrefix + '__label' if classPrefix }}">
   {{ widget.fieldLabel}}
-  {% if not widget.required %} {{ __("(Optional)") }}{% endif %}
+  {% if not widget.required %}<span class="apos-form-field-optional"> {{ __("(Optional)") }}</span>{% endif %}
   <span class="apos-forms-label-message {{ classPrefix + '__label-message' if classPrefix }}" data-apos-input-message="{{ widget.fieldName}}" hidden></span>
   <span class="apos-forms-label-message {{ classPrefix + '__label-message' if classPrefix }}" data-apos-forms-file-spinner hidden>Uploading...</span>
   <span class="apos-forms-error apos-forms-label-message {{classPrefix + '__error' if classPrefix }} {{ classPrefix + '__label-message' if classPrefix }}" data-apos-forms-file-error role="alert" hidden>An error occurred uploading the file. It may be too large or of an inappropriate type.</span>

--- a/lib/modules/apostrophe-forms-radio-field-widgets/views/widget.html
+++ b/lib/modules/apostrophe-forms-radio-field-widgets/views/widget.html
@@ -2,13 +2,27 @@
 {% set id = apos.utils.generateId() %}
 {% set widget = data.widget %}
 {% set classPrefix = data.widget.classPrefix %}
+{% set radioLabel = module.getOption('optionLabelPosition', 'legacy') %}
 <fieldset class="apos-forms-fieldset {{ classPrefix + '__fieldset' if classPrefix }}">
   <legend {% if classPrefix %}class="{{classPrefix + '__legend' }}"{% endif %}>{{ widget.fieldLabel}}</legend>
   {% if not widget.required %} {{ __("(Optional)") }}{% endif %}
   {% for choice in widget.choices %}
     {% set choiceId = id + apos.utils.slugify(choice.value) %}
-    <input {% if classPrefix %}class="{{classPrefix + '__input' }}"{% endif %} type="radio" id="{{ choiceId }}" name="{{ widget.fieldName}}" value="{{ choice.value }}">
-    <label {% if classPrefix %}class="{{classPrefix + '__label' }}"{% endif %} for="{{ choiceId }}">{{ choice.label }}</label>
+    {% if radioLabel == 'first' %}
+      <label {% if classPrefix %}class="{{classPrefix + '__label' }}"{% endif %} for="{{ choiceId }}">
+        {{ choice.label }}
+        <input {% if classPrefix %}class="{{classPrefix + '__input' }}"{% endif %} type="radio" id="{{ choiceId }}" name="{{ widget.fieldName}}" value="{{ choice.value }}">
+      </label>
+    {% elseif radioLabel == 'last' %}
+      <label {% if classPrefix %}class="{{classPrefix + '__label' }}"{% endif %} for="{{ choiceId }}">
+        <input {% if classPrefix %}class="{{classPrefix + '__input' }}"{% endif %} type="radio" id="{{ choiceId }}" name="{{ widget.fieldName}}" value="{{ choice.value }}">
+        {{ choice.label }}
+      </label>
+    {% else %}
+      {# Legacy #}
+      <input {% if classPrefix %}class="{{classPrefix + '__input' }}"{% endif %} type="radio" id="{{ choiceId }}" name="{{ widget.fieldName}}" value="{{ choice.value }}">
+      <label {% if classPrefix %}class="{{classPrefix + '__label' }}"{% endif %} for="{{ choiceId }}">{{ choice.label }}</label>
+    {% endif %}
   {% endfor %}
   <p data-apos-input-message="{{ widget.fieldName}}" hidden></p>
 </fieldset>

--- a/lib/modules/apostrophe-forms-radio-field-widgets/views/widget.html
+++ b/lib/modules/apostrophe-forms-radio-field-widgets/views/widget.html
@@ -5,7 +5,7 @@
 {% set radioLabel = module.getOption('optionLabelPosition', 'legacy') %}
 <fieldset class="apos-forms-fieldset {{ classPrefix + '__fieldset' if classPrefix }}">
   <legend {% if classPrefix %}class="{{classPrefix + '__legend' }}"{% endif %}>{{ widget.fieldLabel}}</legend>
-  {% if not widget.required %} {{ __("(Optional)") }}{% endif %}
+  {% if not widget.required %}<span class="apos-form-field-optional"> {{ __("(Optional)") }}</span>{% endif %}
   {% for choice in widget.choices %}
     {% set choiceId = id + apos.utils.slugify(choice.value) %}
     {% if radioLabel == 'first' %}

--- a/lib/modules/apostrophe-forms-select-field-widgets/views/widget.html
+++ b/lib/modules/apostrophe-forms-select-field-widgets/views/widget.html
@@ -4,7 +4,7 @@
 {% set classPrefix = data.widget.classPrefix %}
 <label for="{{ id }}" class="apos-forms-label {{ classPrefix + '__label' if classPrefix }}">
   {{ widget.fieldLabel}}
-  {% if not widget.required %} {{ __("(Optional)") }}{% endif %}
+  {% if not widget.required %}<span class="apos-form-field-optional"> {{ __("(Optional)") }}</span>{% endif %}
   <span class="apos-forms-label-message {{ classPrefix + '__label-message' if classPrefix }}" data-apos-input-message="{{ widget.fieldName}}" hidden></span>
 </label>
 <select class="apos-forms-input {{ classPrefix + '__input' if classPrefix }}" id="{{ id }}" name="{{ widget.fieldName}}" {% if widget.required %}required{% endif %}>

--- a/lib/modules/apostrophe-forms-text-field-widgets/views/widget.html
+++ b/lib/modules/apostrophe-forms-text-field-widgets/views/widget.html
@@ -4,7 +4,7 @@
 {% set classPrefix = data.widget.classPrefix %}
 <label for="{{ id }}" class="apos-forms-label {{ classPrefix + '__label' if classPrefix }}">
   {{ widget.fieldLabel}}
-  {% if not widget.required %} {{ __("(Optional)") }}{% endif %}
+  {% if not widget.required %}<span class="apos-form-field-optional"> {{ __("(Optional)") }}</span>{% endif %}
   <span class="apos-forms-label-message {{ classPrefix + '__label-message' if classPrefix }}" data-apos-input-message="{{ widget.fieldName}}" hidden></span>
 </label>
 {% if widget.inputType == 'date' %}

--- a/lib/modules/apostrophe-forms-textarea-field-widgets/views/widget.html
+++ b/lib/modules/apostrophe-forms-textarea-field-widgets/views/widget.html
@@ -4,7 +4,7 @@
 {% set classPrefix = data.widget.classPrefix %}
 <label for="{{ id }}" class="apos-forms-label {{ classPrefix + '__label' if classPrefix }}">
   {{ widget.fieldLabel}}
-  {% if not widget.required %} {{ __("(Optional)") }}{% endif %}
+  {% if not widget.required %}<span class="apos-form-field-optional"> {{ __("(Optional)") }}</span>{% endif %}
   <span class="apos-forms-label-message {{ classPrefix + '__label-message' if classPrefix }}" data-apos-input-message="{{ widget.fieldName}}" hidden></span>
 </label>
 <textarea class="apos-forms-input {{ classPrefix + '__input' if classPrefix }}" id="{{ id }}" name="{{ widget.fieldName}}" placeholder="{{widget.placeholder}}" {% if widget.required %}required{% endif %}></textarea>

--- a/lib/modules/apostrophe-forms-widgets/public/css/forms.less
+++ b/lib/modules/apostrophe-forms-widgets/public/css/forms.less
@@ -1,5 +1,6 @@
 // Colors
 @apos-forms-red: #EA433A;
+
 // Spacing
 @apos-forms-spacing: 20px;
 

--- a/public/css/lean.less
+++ b/public/css/lean.less
@@ -43,10 +43,8 @@
     display: block;
     line-height: 1.5;
   }
+  .apos-forms-checkboxes--dropdown-active & {
+    height: auto;
+    overflow: auto;
+  }
 }
-
-.apos-forms-checkboxes--dropdown.apos-forms-checkboxes--dropdown-active .apos-forms-checkboxes-dropdown-choices {
-  height: auto;
-  overflow: auto;
-}
-

--- a/public/css/lean.less
+++ b/public/css/lean.less
@@ -17,20 +17,20 @@
   }
 }
 
-.apos-forms-checkboxes-dropdown {
+.apos-forms-checkboxes--dropdown {
   display: inline-block;
 }
 
-.apos-forms-checkboxes-dropdown [data-apos-toggle] {
+.apos-forms-checkboxes--dropdown [data-apos-toggle] {
   width: auto;
 }
 
-.apos-forms-checkboxes-dropdown [data-apos-toggle]:after {
+.apos-forms-checkboxes--dropdown [data-apos-toggle]:after {
   padding-left: 2em;
   content: '▶';
 }
 
-.apos-forms-checkboxes-dropdown--active [data-apos-toggle]:after {
+.apos-forms-checkboxes--dropdown-active [data-apos-toggle]:after {
   padding-left: 2em;
   content: '▲';
 }
@@ -49,7 +49,7 @@
   }
 }
 
-.apos-forms-checkboxes-dropdown.apos-forms-checkboxes-dropdown--active .apos-forms-checkboxes-dropdown-choices {
+.apos-forms-checkboxes--dropdown.apos-forms-checkboxes--dropdown-active .apos-forms-checkboxes-dropdown-choices {
   height: auto;
   overflow: auto;
 }

--- a/public/css/lean.less
+++ b/public/css/lean.less
@@ -21,16 +21,16 @@
   display: inline-block;
 }
 
-.apos-forms-checkboxes--dropdown [data-apos-toggle] {
+.apos-forms-checkboxes-toggle {
   width: auto;
 }
 
-.apos-forms-checkboxes--dropdown [data-apos-toggle]:after {
+.apos-forms-checkboxes-toggle:after {
   padding-left: 2em;
   content: '▶';
 }
 
-.apos-forms-checkboxes--dropdown-active [data-apos-toggle]:after {
+.apos-forms-checkboxes--dropdown-active .apos-forms-checkboxes-toggle:after {
   padding-left: 2em;
   content: '▲';
 }

--- a/public/css/lean.less
+++ b/public/css/lean.less
@@ -26,10 +26,10 @@
 }
 
 .apos-forms-checkboxes-toggle:after {
-  padding-left: 2em;
+  padding-left: 24px;
   content: '▶';
   .apos-forms-checkboxes-dropdown--active & {
-    padding-left: 2em;
+    padding-left: 24px;
     content: '▲';
   }
 }

--- a/public/css/lean.less
+++ b/public/css/lean.less
@@ -42,9 +42,6 @@
     width: auto;
     display: block;
     line-height: 1.5;
-    &:first-child {
-      margin-top: 0.5em;
-    }
   }
 }
 

--- a/public/css/lean.less
+++ b/public/css/lean.less
@@ -28,11 +28,10 @@
 .apos-forms-checkboxes-toggle:after {
   padding-left: 2em;
   content: '▶';
-}
-
-.apos-forms-checkboxes--dropdown-active .apos-forms-checkboxes-toggle:after {
-  padding-left: 2em;
-  content: '▲';
+  .apos-forms-checkboxes-dropdown--active & {
+    padding-left: 2em;
+    content: '▲';
+  }
 }
 
 .apos-forms-checkboxes-dropdown-choices {

--- a/public/css/lean.less
+++ b/public/css/lean.less
@@ -16,3 +16,41 @@
     margin-bottom: @apos-forms-spacing;
   }
 }
+
+.apos-forms-checkboxes-dropdown {
+  display: inline-block;
+}
+
+.apos-forms-checkboxes-dropdown [data-apos-toggle] {
+  width: auto;
+}
+
+.apos-forms-checkboxes-dropdown [data-apos-toggle]:after {
+  padding-left: 2em;
+  content: '▶';
+}
+
+.apos-forms-checkboxes-dropdown--active [data-apos-toggle]:after {
+  padding-left: 2em;
+  content: '▲';
+}
+
+.apos-forms-checkboxes-dropdown-choices {
+  width: auto;
+  height: 0px;
+  overflow: hidden;
+  label {
+    width: auto;
+    display: block;
+    line-height: 1.5;
+    &:first-child {
+      margin-top: 0.5em;
+    }
+  }
+}
+
+.apos-forms-checkboxes-dropdown.apos-forms-checkboxes-dropdown--active .apos-forms-checkboxes-dropdown-choices {
+  height: auto;
+  overflow: auto;
+}
+


### PR DESCRIPTION
The styling is basic PoC as is generally the case for this module's shipping CSS, but I think the DOM markup is sustainable. Speaking of which, I introduced more sustainable/style-able markup for checkboxes, but for bc I did not impose it by default; see the changelog.