### PR TITLE
Add an event on form submission when reCAPTCHA is unchecked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 1.10.0 2020-06-26
+
+- Adds an event `apostrophe-forms:submission-missing-recaptcha`, which is emitted when a form is submitted before the reCAPTCHA is checked (e.g. expired after a while or invalidated after a failed submission).
+
 ## 1.9.0 2020-06-17
 
 - Introduced multiselect dropdowns as an alternate style choice available to form creators when they select the "checkboxes" widget. The provided CSS is basic but the DOM structure is intended to be suitable for styling as you see fit.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ By default, submissions are saved to a new MongoDB collection, `aposFormSubmissi
 
 Form submission triggers a `'submission'` event that you can listen for and handle in an additional method if you choose. The callback for that event is provided the arguments, `req, form (the form object), output (the submission output)`.
 
-The module also emits browser events on submission (`apostrophe-forms:submission-form`) and submission failure (`apostrophe-forms:submission-failed`). Both events are attached to the document `body` element.
+The module also emits browser events on submission (`apostrophe-forms:submission-form`) and submission failure (`apostrophe-forms:submission-failed`). If reCAPTCHA is enabled (see [Using reCAPTCHA for user validation](#Using-reCAPTCHA-for-user-validation), it emits an event on submission with an unchecked reCAPTCHA (`apostrophe-forms:submissions-missing-recaptcha`). All three events are attached to the document `body` element.
 
 ### Email
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ By default, submissions are saved to a new MongoDB collection, `aposFormSubmissi
 
 Form submission triggers a `'submission'` event that you can listen for and handle in an additional method if you choose. The callback for that event is provided the arguments, `req, form (the form object), output (the submission output)`.
 
-The module also emits browser events on submission (`apostrophe-forms:submission-form`) and submission failure (`apostrophe-forms:submission-failed`). If reCAPTCHA is enabled (see [Using reCAPTCHA for user validation](#Using-reCAPTCHA-for-user-validation), it emits an event on submission with an unchecked reCAPTCHA (`apostrophe-forms:submissions-missing-recaptcha`). All three events are attached to the document `body` element.
+The module also emits browser events on submission (`apostrophe-forms:submission-form`) and submission failure (`apostrophe-forms:submission-failed`). If reCAPTCHA is enabled (see [Using reCAPTCHA for user validation](#Using-reCAPTCHA-for-user-validation)), it emits an event on submission with an unchecked reCAPTCHA (`apostrophe-forms:submissions-missing-recaptcha`). All three events are attached to the document `body` element.
 
 ### Email
 

--- a/lib/modules/apostrophe-forms-widgets/public/js/lean.js
+++ b/lib/modules/apostrophe-forms-widgets/public/js/lean.js
@@ -49,6 +49,10 @@ apos.utils.widgetPlayers['apostrophe-forms'] = function (el, data, options) {
 
       if (!token) {
         apos.utils.addClass(recaptchaError, 'apos-forms-visible');
+        apos.utils.emit(document.body, 'apostrophe-forms:submission-missing-recaptcha', {
+          form: form,
+          recaptchaSlot: recaptchaSlot
+        });
         return;
       }
 


### PR DESCRIPTION
Create and emit the event `apostrophe-forms:submission-missing-recaptcha` when a form is submitted before the reCAPTCHA is checked (e.g. expired after a while, invalidated after failed submission, ...). This allows custom actions to be taken when it happens, in addition to the built-in error message.

Relates to #135 