### PR TITLE
satisfy strict moog-require

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,9 @@
+{
+  "//": "this package.json file is not actually installed",
+  "//": "apostrophe requires that all npm modules to be loaded by moog",
+  "//": "exist in package.json at project level, which for a test is here",
+  "dependencies": {
+    "apostrophe": "^2.0.0",
+    "apostrophe-forms": "^1.0.0"
+  }
+}


### PR DESCRIPTION
This is an edge case where we were cheating by loading apostrophe bundles or modules via require's recursive scan up the tree to parent folders.

Fortunately we can resolve it by declaring our dependencies for the tests even though they actually resolve via the recursive lookup. Which, is exactly what we should do when I think about it.