### PR TITLE
Multiple File Fields now possible inside one Form.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.10.5 (2021-09-07)
+
+- Fixes a bug where only the first input of type "file" was being submitted on form submit.
+
 ## 1.10.4 (2021-08-27)
 
 - Use `self.getOption` to fetch the recaptcha options for full compatibility with `apostrophe-override-options`.

--- a/lib/modules/apostrophe-forms-file-field-widgets/public/js/lean.js
+++ b/lib/modules/apostrophe-forms-file-field-widgets/public/js/lean.js
@@ -1,6 +1,6 @@
 apos.utils.widgetPlayers['apostrophe-forms-file-field'] = function (el, data, options) {
 
-  let inputFile = el.querySelector('input');
+  var inputFile = el.querySelector('input');
 
   var formsWidget = apos.utils.closest(el, '[data-apos-widget="apostrophe-forms"]');
   if (!formsWidget) {
@@ -8,8 +8,7 @@ apos.utils.widgetPlayers['apostrophe-forms-file-field'] = function (el, data, op
     return;
   }
 
-  //var fileArr = formsWidget.querySelectorAll('input[type="file"]');
-  var spinner = formsWidget.querySelector('[data-apos-forms-file-spinner]');
+  var spinner = el.querySelector('[data-apos-forms-file-spinner]');
 
   formsWidget.addEventListener('apos-forms-validate', function (event) {
     // We already did the hard work, this is a hidden field with the _id of the
@@ -18,12 +17,13 @@ apos.utils.widgetPlayers['apostrophe-forms-file-field'] = function (el, data, op
     event.input[inputFile.getAttribute('name')] = attachmentIds ? attachmentIds.split(',') : null;
   });
 
-  var error = formsWidget.querySelector('[data-apos-forms-file-error]');
+  var error = el.querySelector('[data-apos-forms-file-error]');
   error.hidden = true;
 
   inputFile.addEventListener('change', function (event) {
     el.setAttribute('data-apos-forms-busy', '1');
     spinner.hidden = false;
+    error.hidden = true;
 
     sendFiles(inputFile, inputFile.files, 0, []);
   });
@@ -59,6 +59,7 @@ apos.utils.widgetPlayers['apostrophe-forms-file-field'] = function (el, data, op
 
   function fail() {
     error.hidden = false;
+    spinner.hidden = true;
     inputFile.removeAttribute('data-apos-forms-attachment-ids');
   }
 };

--- a/lib/modules/apostrophe-forms-file-field-widgets/public/js/lean.js
+++ b/lib/modules/apostrophe-forms-file-field-widgets/public/js/lean.js
@@ -25,11 +25,11 @@ apos.utils.widgetPlayers['apostrophe-forms-file-field'] = function (el, data, op
     spinner.hidden = false;
     error.hidden = true;
 
-    sendFiles(inputFile, inputFile.files, 0, []);
+    sendFiles(inputFile.files, 0, []);
   });
 
 
-  function sendFiles(file, files, fileIndex, fileIds) {
+  function sendFiles(files, fileIndex, fileIds) {
     var formData = new window.FormData();
     formData.append('file', files[fileIndex]);
 
@@ -46,9 +46,9 @@ apos.utils.widgetPlayers['apostrophe-forms-file-field'] = function (el, data, op
       fileIndex++;
 
       if (files[fileIndex]) {
-        sendFiles(file, files, fileIndex, fileIds);
+        sendFiles(files, fileIndex, fileIds);
       } else {
-        file.setAttribute('data-apos-forms-attachment-ids', fileIds.join());
+        inputFile.setAttribute('data-apos-forms-attachment-ids', fileIds.join());
 
         // Remove the busy state.
         el.removeAttribute('data-apos-forms-busy');

--- a/lib/modules/apostrophe-forms-file-field-widgets/public/js/lean.js
+++ b/lib/modules/apostrophe-forms-file-field-widgets/public/js/lean.js
@@ -1,4 +1,6 @@
-apos.utils.widgetPlayers['apostrophe-forms-file-field'] = function(el, data, options) {
+apos.utils.widgetPlayers['apostrophe-forms-file-field'] = function (el, data, options) {
+
+  let inputFile = el.querySelector('input');
 
   var formsWidget = apos.utils.closest(el, '[data-apos-widget="apostrophe-forms"]');
   if (!formsWidget) {
@@ -6,27 +8,28 @@ apos.utils.widgetPlayers['apostrophe-forms-file-field'] = function(el, data, opt
     return;
   }
 
-  var file = formsWidget.querySelector('input[type="file"]');
+  //var fileArr = formsWidget.querySelectorAll('input[type="file"]');
   var spinner = formsWidget.querySelector('[data-apos-forms-file-spinner]');
 
-  formsWidget.addEventListener('apos-forms-validate', function(event) {
+  formsWidget.addEventListener('apos-forms-validate', function (event) {
     // We already did the hard work, this is a hidden field with the _id of the
     // attachment.
-    var attachmentIds = file.getAttribute('data-apos-forms-attachment-ids');
-    event.input[file.getAttribute('name')] = attachmentIds ? attachmentIds.split(',') : null;
+    var attachmentIds = inputFile.getAttribute('data-apos-forms-attachment-ids');
+    event.input[inputFile.getAttribute('name')] = attachmentIds ? attachmentIds.split(',') : null;
   });
 
   var error = formsWidget.querySelector('[data-apos-forms-file-error]');
   error.hidden = true;
 
-  file.addEventListener('change', function(event) {
+  inputFile.addEventListener('change', function (event) {
     el.setAttribute('data-apos-forms-busy', '1');
     spinner.hidden = false;
 
-    sendFiles(file.files, 0, []);
+    sendFiles(inputFile, inputFile.files, 0, []);
   });
 
-  function sendFiles(files, fileIndex, fileIds) {
+
+  function sendFiles(file, files, fileIndex, fileIds) {
     var formData = new window.FormData();
     formData.append('file', files[fileIndex]);
 
@@ -43,7 +46,7 @@ apos.utils.widgetPlayers['apostrophe-forms-file-field'] = function(el, data, opt
       fileIndex++;
 
       if (files[fileIndex]) {
-        sendFiles(files, fileIndex, fileIds);
+        sendFiles(file, files, fileIndex, fileIds);
       } else {
         file.setAttribute('data-apos-forms-attachment-ids', fileIds.join());
 
@@ -56,6 +59,6 @@ apos.utils.widgetPlayers['apostrophe-forms-file-field'] = function(el, data, opt
 
   function fail() {
     error.hidden = false;
-    file.removeAttribute('data-apos-forms-attachment-ids');
+    inputFile.removeAttribute('data-apos-forms-attachment-ids');
   }
 };


### PR DESCRIPTION
I was struggling to get multiple input[type=file] working in Apostrophe CMS Forms. Only the first one got sent. So I updated the code to handle multiple file inputs inside one form.