### PR TITLE
Allow conditional section to match any value from comma-seperated list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.10.6 (2022-01-25)
+
+- Allow conditional section to match any value from a comma-seperated list.
+
 ## 1.10.5 (2021-09-07)
 
 - Fixes a bug where only the first input of type "file" was being submitted on form submit.

--- a/lib/modules/apostrophe-forms-conditional-widgets/index.js
+++ b/lib/modules/apostrophe-forms-conditional-widgets/index.js
@@ -13,7 +13,7 @@ module.exports = {
       {
         name: 'conditionValue',
         label: 'Value to check for to show this group.',
-        htmlHelp: 'If using a <strong>boolean/opt-in field</strong>, set this to "true".',
+        htmlHelp: 'If using a <strong>boolean/opt-in field</strong>, set this to "true". Use comma-separated values to check multiple values on this field (an OR relationship).',
         required: true,
         type: 'string'
       },

--- a/lib/modules/apostrophe-forms-conditional-widgets/public/js/lean.js
+++ b/lib/modules/apostrophe-forms-conditional-widgets/public/js/lean.js
@@ -21,7 +21,14 @@ apos.aposForms.checkConditional = function (groups, input) {
       activate = false;
     }
 
-    if (input.value === conditionValue && activate) {
+    var conditionCommaArray = conditionValue.split(',');
+
+    var inputMatchesCondition = false;
+    if (conditionCommaArray.indexOf(input.value) > -1) {
+      inputMatchesCondition = true;
+    }
+
+    if (inputMatchesCondition || (input.value === conditionValue && activate)) {
       fieldSet.removeAttribute('disabled');
     } else {
       fieldSet.setAttribute('disabled', true);


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Allow conditional section to match any value from comma-seperated list.
Prior to this, conditional groups only allowed matching ONE option (eg. from a select dropdown). This should allow matching multiple options.
Useful when you need to show a conditional section based on a select dropdown where more than one option satisfy the condition.

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*

## What are the specific steps to test this change?

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [x] Related documentation has been updated
- [ ] Related tests have been updated

**Other information:**
Needs to be tested properly.