### PR TITLE
add choices, conditionName, conditionValue & contents to arrangeFields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## next
+
+- add `apostrophe-forms-checkboxes-field-widgets` `choices` to `arrangeFields` to prevent warning during startup
+- add `apostrophe-forms-conditional-widgets` `conditionName`, `conditionValue` & `contents` to `arrangeFields` to prevent warning during startup
+
 ## 1.10.5 (2021-10-13)
 
 - Fixes a bug where only the first input of type "file" was being submitted on form submit.

--- a/lib/modules/apostrophe-forms-checkboxes-field-widgets/index.js
+++ b/lib/modules/apostrophe-forms-checkboxes-field-widgets/index.js
@@ -42,6 +42,11 @@ module.exports = {
     }
   ],
   construct: function (self, options) {
+    const settings = options.arrangeFields.find(group => group.name === 'settings');
+    if (settings) {
+      group.fields.push('choices');
+    }
+
     const advanced = options.arrangeFields.find(group => group.name === 'advanced');
     if (!advanced) {
       options.arrangeFields.push({

--- a/lib/modules/apostrophe-forms-conditional-widgets/index.js
+++ b/lib/modules/apostrophe-forms-conditional-widgets/index.js
@@ -29,6 +29,23 @@ module.exports = {
     ].concat(options.addFields || []);
   },
   construct: function (self, options) {
+    const settings = options.arrangeFields.find(group => group.name === 'settings');
+    if (!settings) {
+      options.arrangeFields.push({
+        name: 'settings',
+        label: 'Field settings',
+        fields: [
+          'conditionName',
+          'conditionValue',
+          'contents'
+        ]
+      });
+    } else {
+      group.fields.push('conditionName');
+      group.fields.push('conditionValue');
+      group.fields.push('contents');
+    }
+
     self.pushAsset('script', 'lean', { when: 'lean' });
 
     const forms = self.apos.modules['apostrophe-forms'];


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

During startup, apostrophe will display the following warning:

```
⚠️ widget type apostrophe-forms-checkboxes-field contains unarranged field(s): choices.
Arrange all of your fields with arrangeFields, using meaningful group labels.
https://apos.dev/arrange-fields
```

`apostrophe-forms-checkboxes-field-widgets` extends `apostrophe-forms-base-field-widgets` which has a `settings` group.

```
⚠️ widget type apostrophe-forms-conditional contains unarranged field(s): conditionName, conditionValue, contents.
Arrange all of your fields with arrangeFields, using meaningful group labels.
https://apos.dev/arrange-fields
```

`apostrophe-forms-conditional-widgets` extends `apostrophe-widgets` which has no `settings` group, but it's possible to have extended it on a project.

## What are the specific steps to test this change?

1. Start apostrophe e.g. `npm start`
2. Check `stdout` for warnings

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] ~~Related documentation has been updated~~
- [ ] ~~Related tests have been updated~~

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
